### PR TITLE
Update ansible-ssh

### DIFF
--- a/ansible-ssh
+++ b/ansible-ssh
@@ -5,6 +5,14 @@
 
 ARG=$1
 
+if [ ${ARG:0:10} == "host_vars/" ] ; then
+	echo Found host_vars-file as argument
+	ARG=${ARG:10:${#ARG}}
+	ARG=${ARG:0:${#ARG} - 4}
+	echo revised argument: $ARG
+	
+fi
+
 JQ=$(which jq)
 
 if [ -z "$ARG" ] ; then


### PR DESCRIPTION
der hostname muss nun nicht länger manuell eingegeben werden, sondern kann OPTIONAL per "tab completion" aus den Dateinamen der host_vars übernommen werden.

Bsp.:

./ansible-ssh host_vars/proxmox01.gst.hamburg.adfc.de.yml
("./an" tippen + tab + "ho" tippen + tab + "pr" tippen + tab)

statt

./ansible-ssh proxmox01.gst.hamburg.adfc.de
("./an" tippen + tab + "proxmox01.gst.hamburg.adfc.de" tippen)

getestet unter macos