### PR TITLE
web-weiterleitung per script erstellt

### DIFF
--- a/ansible-ssh
+++ b/ansible-ssh
@@ -5,6 +5,11 @@
 
 ARG=$1
 
+if [ -z "$ARG" ] ; then
+   echo 'please spezify a hostname' >&2
+   exit 1
+fi
+
 if [ ${ARG:0:10} == "host_vars/" ] ; then
 	echo Found host_vars-file as argument
 	ARG=${ARG:10:${#ARG}}
@@ -15,10 +20,7 @@ fi
 
 JQ=$(which jq)
 
-if [ -z "$ARG" ] ; then
-   echo 'please spezify a hostname' >&2
-   exit 1
-fi
+
 
 if [ -z "$JQ" ] ; then
    echo 'jq not found, please install it with "apt install jq"' >&2

--- a/ansible-web.sh
+++ b/ansible-web.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+
+
+ARG=$1
+
+if [ ${ARG:0:10} == "host_vars/" ] ; then
+        echo Found host_vars-file as argument
+        ARG=${ARG:10:${#ARG}}
+        ARG=${ARG:0:${#ARG} - 4}
+        echo revised argument: $ARG
+
+fi
+
+JQ=$(which jq)
+
+if [ -z "$ARG" ] ; then
+   echo 'please spezify a hostname' >&2
+   exit 1
+fi
+
+if [ -z "$JQ" ] ; then
+   echo 'jq not found, please install it with "apt install jq"' >&2
+   exit 2
+fi
+
+JSON=$(ansible-inventory  --host=${ARG})
+ANSIBLE_HOST=$(echo $JSON |$JQ -r .ansible_host )
+ANSIBLE_PORT=$(echo $JSON |$JQ -r '.ansible_port // 822' )
+ANSIBLE_USER=$(echo $JSON |$JQ -r '.ansible_user // "root"' )
+ANSIBLE_ARGS=$(echo $JSON |$JQ -r '.ansible_ssh_common_args // ""')
+ANSIBLE_WEB_PORT=$(echo $JSON |$JQ -r '.ansible_web_port // "8080"' )
+ANSIBLE_WEB_SUBDIR=$(echo $JSON |$JQ -r '.ansible_web_subdir // ""' )
+
+
+echo $ANSIBLE_HOST
+echo $ANSIBLE_PORT
+echo $ANSIBLE_USER
+echo $ANSIBLE_ARGS
+echo $ANSIBLE_WEB_PORT
+echo $ANSIBLE_WEB_SUBDIR
+
+echo starting webbrowser with address https://127.0.0.1:1$ANSIBLE_WEB_PORT$ANSIBLE_WEB_SUBDIR
+echo remote port: $ANSIBLE_WEB_PORT, locale port: 1$ANSIBLE_WEB_PORT
+python -mwebbrowser https://127.0.0.1:1$ANSIBLE_WEB_PORT$ANSIBLE_WEB_SUBDIR &
+
+echo connecting to host...
+eval ssh -p $ANSIBLE_PORT -L 1$ANSIBLE_WEB_PORT:$ANSIBLE_HOST:$ANSIBLE_WEB_PORT root@babelfish.spdns.de

--- a/ansible-web.sh
+++ b/ansible-web.sh
@@ -3,6 +3,11 @@
 
 
 ARG=$1
+if [ -z "$ARG" ] ; then
+   echo 'please spezify a hostname' >&2
+   exit 1
+fi
+
 
 if [ ${ARG:0:10} == "host_vars/" ] ; then
         echo Found host_vars-file as argument
@@ -14,10 +19,6 @@ fi
 
 JQ=$(which jq)
 
-if [ -z "$ARG" ] ; then
-   echo 'please spezify a hostname' >&2
-   exit 1
-fi
 
 if [ -z "$JQ" ] ; then
    echo 'jq not found, please install it with "apt install jq"' >&2
@@ -33,16 +34,9 @@ ANSIBLE_WEB_PORT=$(echo $JSON |$JQ -r '.ansible_web_port // "8080"' )
 ANSIBLE_WEB_SUBDIR=$(echo $JSON |$JQ -r '.ansible_web_subdir // ""' )
 
 
-echo $ANSIBLE_HOST
-echo $ANSIBLE_PORT
-echo $ANSIBLE_USER
-echo $ANSIBLE_ARGS
-echo $ANSIBLE_WEB_PORT
-echo $ANSIBLE_WEB_SUBDIR
-
 echo starting webbrowser with address https://127.0.0.1:1$ANSIBLE_WEB_PORT$ANSIBLE_WEB_SUBDIR
 echo remote port: $ANSIBLE_WEB_PORT, locale port: 1$ANSIBLE_WEB_PORT
 python -mwebbrowser https://127.0.0.1:1$ANSIBLE_WEB_PORT$ANSIBLE_WEB_SUBDIR &
 
-echo connecting to host...
-eval ssh -p $ANSIBLE_PORT -L 1$ANSIBLE_WEB_PORT:$ANSIBLE_HOST:$ANSIBLE_WEB_PORT root@babelfish.spdns.de
+echo connecting to host $ARG ...
+ssh -p $ANSIBLE_PORT -L 1$ANSIBLE_WEB_PORT:$ANSIBLE_HOST:$ANSIBLE_WEB_PORT root@babelfish.spdns.de

--- a/host_vars/proxmox01.gst.hamburg.adfc.de.yml
+++ b/host_vars/proxmox01.gst.hamburg.adfc.de.yml
@@ -1,2 +1,4 @@
 ansible_ssh_common_args: '-o ProxyCommand="ssh -W %h:%p -q root@babelfish.spdns.de -p 2222"'
-ansible_host: 192.168.123.29
+ansible_host: 192.168.123.3
+ansible_web_port: 8006
+ansible_web_subdir: '/'

--- a/host_vars/ucs-master.gst.hamburg.adfc.de.yml
+++ b/host_vars/ucs-master.gst.hamburg.adfc.de.yml
@@ -1,2 +1,4 @@
 ansible_ssh_common_args: '-o ProxyCommand="ssh -W %h:%p -q root@babelfish.spdns.de -p 2222"'
 ansible_host: 192.168.123.32
+ansible_web_port: 443
+ansible_web_subdir: '/univention'


### PR DESCRIPTION
ansible-web.sh erstellt

Benutzung: ./ansible-web.sh +host bzw. +hostvar/...

Das Skript öffnet per python einen webbrowser zur Zielseite und erstellt eine Portweiterleitung.
Am lokalen Port wird eine "1" am Anfang hinzugefügt um Kollisionen mit z.B. Port 443 zu vermeiden.

Die Host_vars Dateien für die Server mussten um die Variablen "ansible_web_port" und "ansible_web_subdir" erweitert werden.