### PR TITLE
Postfix sasl+check ips

### DIFF
--- a/files/check_ips.sh
+++ b/files/check_ips.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+##
+## Script wird über ansible deployed
+##
+
+ping_targets="192.168.123.32"
+failed_hosts=""
+
+for i in $ping_targets
+do
+   ping -c 1 $i > /dev/null
+   if [ $? -ne 0 ]; then
+      if [ "$failed_hosts" == "" ]; then
+         failed_hosts="$i"
+      else
+         failed_hosts="$failed_hosts, $i"
+      fi
+   fi
+done
+
+if [ "$failed_hosts" != "" ]; then
+   echo $failed_hosts| mailx -r "proxmox01" -s "Host nicht erreichbar:"  ak-computer@lists.hamburg.adfc.de
+fi

--- a/host_vars/proxmox01.gst.hamburg.adfc.de.yml
+++ b/host_vars/proxmox01.gst.hamburg.adfc.de.yml
@@ -2,3 +2,4 @@ ansible_ssh_common_args: '-o ProxyCommand="ssh -W %h:%p -q root@babelfish.spdns.
 ansible_host: 192.168.123.3
 ansible_web_port: 8006
 ansible_web_subdir: '/'
+postfix_host_email: proxmox01@hamburg.adfc.de

--- a/roles/postfix-auth/tasks/main.yml
+++ b/roles/postfix-auth/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+# Playbook to configure Postfix on Proxmox to be able to send emails to admins
+
+- name: Install libsasl2-modules to prevent "no mechanisms found error"
+  apt:
+    name: libsasl2-modules
+    state: present
+
+- name: copy postfix configuration file
+  template: 
+    src: postfix-main.cf
+    dest: /etc/postfix/main.cf
+    mode: 0644
+
+- name: copy sender_canonical 
+  template:
+    src: sender-canonical
+    dest: /etc/postfix/sender_canonical
+    mode: 0640
+
+- name: Check that smtp_auth file exists
+  stat:
+    path: /etc/postfix/smtp_auth
+  register: sym
+
+- debug:
+    msg: "smtp_auth does not exist"
+  when: sym.stat.exists == False
+
+- name: Do postmap on smtp_auth
+  command: /usr/sbin/postmap /etc/postfix/smtp_auth
+  args:
+    creates: /etc/postfix/smtp_auth.db
+
+- name: reload postfix
+  service:
+    name: postfix
+    state: restarted

--- a/roles/postfix-auth/tasks/main.yml
+++ b/roles/postfix-auth/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
-# Playbook to configure Postfix on Proxmox to be able to send emails to admins
+# Playbook to configure Postfix on a server to be able to send emails to admins
 
-- name: Install libsasl2-modules to prevent "no mechanisms found error"
+- name: install libsasl2-modules to prevent "no mechanisms found error"
   apt:
     name: libsasl2-modules
     state: present
@@ -21,11 +21,11 @@
 - name: Check that smtp_auth file exists
   stat:
     path: /etc/postfix/smtp_auth
-  register: sym
+  register: smtp_auth
 
 - debug:
     msg: "smtp_auth does not exist"
-  when: sym.stat.exists == False
+  when: smtp_auth.stat.exists == False
 
 - name: Do postmap on smtp_auth
   command: /usr/sbin/postmap /etc/postfix/smtp_auth

--- a/roles/postfix-auth/tasks/main.yml
+++ b/roles/postfix-auth/tasks/main.yml
@@ -23,7 +23,7 @@
     path: /etc/postfix/smtp_auth
   register: smtp_auth
 
-- debug:
+- fail:
     msg: "smtp_auth does not exist"
   when: smtp_auth.stat.exists == False
 

--- a/roles/postfix-auth/templates/postfix-main.cf
+++ b/roles/postfix-auth/templates/postfix-main.cf
@@ -1,0 +1,32 @@
+myhostname={{ ansible_fqdn }}
+
+compatibility_level=2
+
+smtpd_banner = $myhostname ESMTP $mail_name (Debian/GNU)
+biff = no
+
+# appending .domain is the MUA's job.
+append_dot_mydomain = no
+
+# Uncomment the next line to generate "delayed mail" warnings
+#delay_warning_time = 4h
+
+alias_maps = hash:/etc/aliases
+alias_database = hash:/etc/aliases
+mydestination = $myhostname, localhost.$mydomain, localhost
+mynetworks = 127.0.0.0/8
+inet_interfaces = loopback-only
+recipient_delimiter = +
+
+# Configuration for using a relay host
+relayhost = sslout.df.eu
+smtp_sasl_auth_enable = yes
+smtp_sasl_password_maps = hash:/etc/postfix/smtp_auth
+smtp_sasl_security_options = noanonymous
+
+# Configuration for smtp security
+smtp_tls_security_level = may
+
+# Ensure sender address gets remapped to a valid value
+sender_canonical_maps = regexp:/etc/postfix/sender_canonical
+

--- a/roles/postfix-auth/templates/postfix-main.cf
+++ b/roles/postfix-auth/templates/postfix-main.cf
@@ -25,8 +25,12 @@ smtp_sasl_password_maps = hash:/etc/postfix/smtp_auth
 smtp_sasl_security_options = noanonymous
 
 # Configuration for smtp security
-smtp_tls_security_level = may
+smtp_tls_security_level = encrypt
+smtp_tls_mandatory_ciphers = high
 
 # Ensure sender address gets remapped to a valid value
 sender_canonical_maps = regexp:/etc/postfix/sender_canonical
+
+# Logging
+smtp_tls_loglevel = 1
 

--- a/roles/postfix-auth/templates/sender-canonical
+++ b/roles/postfix-auth/templates/sender-canonical
@@ -1,0 +1,1 @@
+/^.*gst.hamburg.adfc.de$/   {{ postfix_host_email }}

--- a/setup-proxmox.yml
+++ b/setup-proxmox.yml
@@ -30,6 +30,10 @@
         repo: "deb http://download.proxmox.com/debian/pve stretch pve-no-subscription"
         filename: "proxmox"
         state: present
+
+    - name: Sicherstellen das bsd-mailx installiert ist
+      apt:
+        name: bsd-mailx   
     
     - name: Kopiere check_ip Skript
       copy:

--- a/setup-proxmox.yml
+++ b/setup-proxmox.yml
@@ -1,7 +1,8 @@
 - hosts: proxmox01.gst.hamburg.adfc.de
-  gather_facts: no
+  gather_facts: yes
   roles:
     - ssh-keys
+    - postfix-auth
   tasks:
     - name: Erstellen eine Unix User fuer Tools-Server Backup
       user:
@@ -29,3 +30,17 @@
         repo: "deb http://download.proxmox.com/debian/pve stretch pve-no-subscription"
         filename: "proxmox"
         state: present
+    
+    - name: Kopiere check_ip Skript
+      copy:
+        src: check_ips.sh
+        dest: /usr/local/bin/check_ips.sh
+        mode: 0755
+
+    - name: Erstelle cron Eintrag für check_ips
+      cron:
+        name: "check_ips"
+        minute: "0"
+        job: "/usr/local/bin/check_ips.sh"
+        cron_file: "adfc_ansible"
+        user: root


### PR DESCRIPTION
Neue Rolle postfix_auth hinzugefügt für server die selbst kein Mailserver sind, aber Mails verschicken sollen über einen anderen Mailserver, z.B. Server Status Meldungen

Skript um zu prüfen ob der UCS Master noch läuft und gegebenenfalls die Mailingliste informiert.