### PR TITLE
hibiscus from source not debian package

### DIFF
--- a/roles/hibiscus/SOURCE
+++ b/roles/hibiscus/SOURCE
@@ -1,0 +1,1 @@
+https://github.com/panticz/ansible/tree/master/roles

--- a/roles/hibiscus/defaults/main.yml
+++ b/roles/hibiscus/defaults/main.yml
@@ -1,0 +1,1 @@
+hibiscus_archive_url: http://www.willuhn.de/products/hibiscus/releases/current/hibiscus.zip

--- a/roles/hibiscus/meta/main.yml
+++ b/roles/hibiscus/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - jameica

--- a/roles/hibiscus/tasks/main.yml
+++ b/roles/hibiscus/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- unarchive:
+    src: "{{ hibiscus_archive_url }}"
+    remote_src: yes
+    dest: /opt/jameica/plugins
+    creates: /opt/jameica/plugins/hibiscus
+    owner: root
+    group: root

--- a/roles/jameica/SOURCE
+++ b/roles/jameica/SOURCE
@@ -1,0 +1,1 @@
+https://github.com/panticz/ansible/tree/master/roles

--- a/roles/jameica/defaults/main.yml
+++ b/roles/jameica/defaults/main.yml
@@ -1,0 +1,1 @@
+jameica_archive_url: http://www.willuhn.de/products/jameica/releases/current/jameica/jameica-linux64.zip

--- a/roles/jameica/files/jameica.desktop
+++ b/roles/jameica/files/jameica.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Version=1.0
+Encoding=UTF-8
+Name=Jameica / Hibiscus
+Type=Application
+Terminal=false
+Exec=/opt/jameica/jameica.sh
+Icon=/opt/jameica/jameica-icon.png
+Categories=Office;Finance;

--- a/roles/jameica/tasks/main.yml
+++ b/roles/jameica/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+- name: Create required directories
+  file:
+    path: /opt
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
+- unarchive:
+    src: "{{ jameica_archive_url }}"
+    remote_src: yes
+    dest: /opt
+    creates: /opt/jameica
+    owner: root
+    group: root
+
+- name: Create starter
+  copy:
+    src: jameica.desktop
+    dest: /usr/share/applications/
+    owner: root
+    group: root
+    mode: 0755

--- a/setup-client.yml
+++ b/setup-client.yml
@@ -2,7 +2,6 @@
   roles:
   - ssh-keys
   - firefox-client
-
   tasks:
 
 # spezielle Repositories hinzufügen
@@ -12,6 +11,7 @@
   - name: ppa fuer hibiskus hinzu
     apt_repository:
       repo: 'ppa:marko-preuss/hibiscus'
+      state: absent
 
 # benötigte Programme installieren
   - name: Installiere Packete
@@ -45,13 +45,24 @@
       - htop
       - mc
       - openshot-qt
-      - hibiscus-ppa
       - gnucash
       - gnucash-docs
       - bsd-mailx
       - krdc
     tags: software
 
+  - name: uninstall hibiscus-ppa
+    apt:
+      name: hibiscus-ppa
+      state: absent
+    tags: hibiscus
+    # Rollen erst includieren wenn das hibiscus-ppa paktet deinstalliert ist
+  - name: install jameica
+    include_role:
+      name: jameica
+  - name: install hibiscus
+    include_role:
+      name: hibiscus
 
   - name: Downloadverzeichnis für deb-Pakete erstellen
     file:
@@ -179,6 +190,7 @@
       src: desktopthemes/ADFC
       dest: /usr/share/plasma/desktoptheme/
       recursive: yes
+      use_ssh_args: yes
     register: desktoptheme
     tags: gdm
   - name: Copy config for default desktoptheme
@@ -199,6 +211,7 @@
       src: wallpapers/ADFC
       dest: /usr/share/wallpapers/
       recursive: yes
+      use_ssh_args: yes
     register: desktoptheme
     tags: gdm
 
@@ -273,4 +286,3 @@
       validate: '/usr/sbin/visudo -cf %s'
       mode: 0440
     tags: sudo
-


### PR DESCRIPTION
Die Debian/Ubuntu Paktete sind leider häufig veraltet. Deshalb hier eine alternative, die die Paktete aus den Quellen runterlädt.