### PR TITLE
Kontaktadressen in "adfc-secrets"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 .DS_Store
 .project
+*.sec

--- a/adfc-secrets/example.nosec
+++ b/adfc-secrets/example.nosec
@@ -1,0 +1,3 @@
+vpnc_password,<<PASSWORD>>
+vpnc_user,<<USERNAME>>
+vpnc_shared_sec,<<SHARED-SECRET>>

--- a/adfc-secrets/info.md
+++ b/adfc-secrets/info.md
@@ -1,0 +1,1 @@
+access data files (*.sec - files) should be stored separately and should not be synced via github

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -14,4 +14,3 @@ adfc_lan_gateway: 192.168.123.1
 adfc_dns_ip: 192.168.123.32
 adfc_dns_search: gst.hamburg.adfc.de
 deb_name_master_pdf_editor: master-pdf-editor-5.3.22_qt5.amd64.deb
-adfc_notification_email: yml@liquid-center.de

--- a/update-client.yml
+++ b/update-client.yml
@@ -8,10 +8,9 @@
     - 'origin=Ubuntu,archive=${distro_codename}-security'
     - 'o=Ubuntu,a=${distro_codename}-updates'
     unattended_package_blacklist: [playonlinux, wine]
-    unattended_mail: "{{adfc_notification_email}}"
+    unattended_mail: "{{ lookup('csvfile', 'adfc_notification_email file=adfc-secrets/adfc-hh-contacts.sec delimiter=,') }}"
     unattended_install_on_shutdown: false
     unattended_verbose: 0
     unattended_random_sleep: 1800
     unattended_automatic_reboot: true
     unattended_automatic_reboot_time: 03:00
-


### PR DESCRIPTION
Um SPAM - Emails zu vermeiden, wurde die Kontaktadresse aus group_vars/all.yml zu adfc-secrets/adfc-hh-contacts.sec verschoben.

Zudem wurde der temporäre Emailalias durch den konkreten Emailverteiler ersetzt.