### PR TITLE
PDFshuffler statt PDFsam in uralter Version hinzu

### DIFF
--- a/setup-client.yml
+++ b/setup-client.yml
@@ -44,6 +44,7 @@
     tags: software
 
 # benötigte Programme installieren
+# pdfshuffler muss bei Wechsel auf Kubuntu >=19 in pdfarranger geändert werden
   - name: Installiere Packete
     apt:
       name:
@@ -80,6 +81,7 @@
       - krdc
       - pdfmod
       - pdfsam
+      - pdfshuffler
       - skypeforlinux
       - nextcloud-client
       - nextcloud-client-dolphin


### PR DESCRIPTION
PDFShuffler hinzu (statt PDFsam in uralter Version) => hat ebenfalls eine grafische Oberfläche zum Neuanordnen der PDF-Seiten