### PR TITLE
add-adfc-workstations

### DIFF
--- a/host_vars/bob.gst.hamburg.adfc.de.yml
+++ b/host_vars/bob.gst.hamburg.adfc.de.yml
@@ -1,2 +1,2 @@
 ansible_ssh_common_args: '-o ProxyCommand="ssh -W %h:%p -q root@babelfish.spdns.de -p 2222"'
-ansible_host: 192.168.123.33
+ansible_host: 192.168.123.20

--- a/host_vars/ford.gst.hamburg.adfc.de.yml
+++ b/host_vars/ford.gst.hamburg.adfc.de.yml
@@ -1,2 +1,2 @@
 ansible_ssh_common_args: '-o ProxyCommand="ssh -W %h:%p -q root@babelfish.spdns.de -p 2222"'
-ansible_host: 192.168.123.33
+ansible_host: 192.168.123.21

--- a/host_vars/marvin.gst.hamburg.adfc.de.yml
+++ b/host_vars/marvin.gst.hamburg.adfc.de.yml
@@ -1,2 +1,2 @@
 ansible_ssh_common_args: '-o ProxyCommand="ssh -W %h:%p -q root@babelfish.spdns.de -p 2222"'
-ansible_host: 192.168.123.33
+ansible_host: 192.168.123.22

--- a/host_vars/trillian.gst.hamburg.adfc.de.yml
+++ b/host_vars/trillian.gst.hamburg.adfc.de.yml
@@ -1,2 +1,2 @@
 ansible_ssh_common_args: '-o ProxyCommand="ssh -W %h:%p -q root@babelfish.spdns.de -p 2222"'
-ansible_host: 192.168.123.33
+ansible_host: 192.168.123.23

--- a/host_vars/zaphod.gst.hamburg.adfc.de.yml
+++ b/host_vars/zaphod.gst.hamburg.adfc.de.yml
@@ -1,2 +1,2 @@
 ansible_ssh_common_args: '-o ProxyCommand="ssh -W %h:%p -q root@babelfish.spdns.de -p 2222"'
-ansible_host: 192.168.123.33
+ansible_host: 192.168.123.24

--- a/inventory.yml
+++ b/inventory.yml
@@ -10,3 +10,8 @@ all:
       hosts:
         adfc-testclient.gst.hamburg.adfc.de:
         kubuntu-vm.gst.hamburg.adfc.de:
+        bob.gst.hamburg.adfc.de:
+        ford.gst.hamburg.adfc.de:
+        marvin.gst.hamburg.adfc.de:
+        trillian.gst.hamburg.adfc.de:
+        zaphod.gst.hamburg.adfc.de:


### PR DESCRIPTION
Bestandsrechner in inventory.yml aufgenommen.
host_vars der Arbeitsrechner erstellt
Entfernen der Variable "ansible_user" aus host_vars/kubuntu-vm.yml, da diese Variable über "all.yml" bereits gesteuert wird.