### PR TITLE
Rolle client-apt-remove erstellt

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -13,4 +13,8 @@ adfc_lan_net_bits: 24
 adfc_lan_gateway: 192.168.123.1
 adfc_dns_ip: 192.168.123.32
 adfc_dns_search: gst.hamburg.adfc.de
+
+# Paketverwaltung
 deb_name_master_pdf_editor: master-pdf-editor-5.3.22_qt5.amd64.deb
+unwanted_packages: 
+  - pdfsam

--- a/roles/client-apt-remove/tasks/main.yml
+++ b/roles/client-apt-remove/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - name: Remove unwanted packages
   apt:
-    pkg: ['pdfsam', '']
+    pkg: "{{ unwanted_packages }}"
     state: absent
     purge: yes
   tags: software
@@ -19,7 +19,7 @@
   tags: software
 
 
-# Remove specified repository from sources list.
+# Remove specified repository from sources list. Example for future use.
 # - apt_repository:
 #     repo: deb http://archive.canonical.com/ubuntu hardy partner
 #     state: absent

--- a/roles/client-apt-remove/tasks/main.yml
+++ b/roles/client-apt-remove/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+# Remove specified packages. "with_items"-method depreciated. Warning: "This feature will be removed in version 2.11"
+
+- name: Remove unwanted packages
+  apt:
+    pkg: ['pdfsam', '']
+    state: absent
+    purge: yes
+  tags: software
+
+- name: Remove useless packages from the cache
+  apt:
+    autoclean: yes
+  tags: software
+
+- name: Remove dependencies that are no longer required
+  apt:
+    autoremove: yes
+  tags: software
+
+
+# Remove specified repository from sources list.
+# - apt_repository:
+#     repo: deb http://archive.canonical.com/ubuntu hardy partner
+#     state: absent
+#   tags: software
+

--- a/setup-client.yml
+++ b/setup-client.yml
@@ -4,6 +4,7 @@
   - postfix-auth
   - firefox-client
   - jnv.unattended-upgrades
+  - client-apt-remove
 
   tasks:
 


### PR DESCRIPTION
Rolle erstellt, um auf Arbeitsstationen unerwünschte / obsolete Pakete zu entfernen.
Ebenso können unerwünschte Repositories entfernt werden (apt source.list).

Um Pakete von den Servern zu entfernen, muss dies entweder manuell oder über eine eigene Rolle durchgeführt werden.