### PR TITLE
Asterisk monitor 2022

### DIFF
--- a/roles/asterisk/files/restart_asterisk_on_error.sh
+++ b/roles/asterisk/files/restart_asterisk_on_error.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+REJECTS=$(/usr/sbin/asterisk -x "pjsip show registrations" |grep Rejected)
+
+if [ -n "${REJECTS} " ] ; then
+    /bin/systemctl restart asterisk
+fi

--- a/roles/asterisk/files/restart_asterisk_on_error.sh
+++ b/roles/asterisk/files/restart_asterisk_on_error.sh
@@ -2,5 +2,6 @@
 REJECTS=$(/usr/sbin/asterisk -x "pjsip show registrations" |grep Rejected)
 
 if [ -n "${REJECTS}" ] ; then
+    /usr/bin/logger "Astersik pjsip cron restart"
     /bin/systemctl restart asterisk
 fi

--- a/roles/asterisk/files/restart_asterisk_on_error.sh
+++ b/roles/asterisk/files/restart_asterisk_on_error.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 REJECTS=$(/usr/sbin/asterisk -x "pjsip show registrations" |grep Rejected)
 
-if [ -n "${REJECTS} " ] ; then
+if [ -n "${REJECTS}" ] ; then
     /bin/systemctl restart asterisk
 fi

--- a/roles/asterisk/tasks/main.yml
+++ b/roles/asterisk/tasks/main.yml
@@ -102,3 +102,19 @@
     proto: udp
     src: '{{ item }}'
   loop: "{{ asterisk_sip_ips }}"
+
+- name: Create Asterisk Monitor
+  copy:
+    src: restart_asterisk_on_error.sh
+    dest: /usr/local/sbin/restart_asterisk_on_error.sh
+    mode: 0755
+    owner: root
+    group: root
+
+- name: cron entry for monitor
+  ansible.builtin.cron:
+    name: asterisk_restart
+    job:  /usr/local/sbin/restart_asterisk_on_error.sh
+    minute: "12,32,52"
+    user: root
+    cron_file: ansible_asterisk


### PR DESCRIPTION
Wir haben das ca. alle 2-4 Monate das die Verbindung zu Sipgate nicht mehr geht:
```
root@meet:~# asterisk -rc -vv
Asterisk 16.16.1~dfsg-1+deb11u1, Copyright (C) 1999 - 2018, Digium, Inc. and others.
Created by Mark Spencer <markster@digium.com>
Asterisk comes with ABSOLUTELY NO WARRANTY; type 'core show warranty' for details.
This is free software, with components licensed under the GNU General Public
License version 2 and other licenses; you are welcome to redistribute it under
certain conditions. Type 'core show license' for details.
=========================================================================
Connected to Asterisk 16.16.1~dfsg-1+deb11u1 currently running on meet (pid = 25057)
meet*CLI> pjsip show registrations

 <Registration/ServerURI..............................>  <Auth..........>  <Status.......>
==========================================================================================

 reg_sipgate_2086851/sip:sipgate.de:5060                 auth_reg_sipgate_2086851  Rejected        

Objects found: 1

meet*CLI> 
meet*CLI> exit
Asterisk cleanly ending (0).
Executing last minute cleanups
root@meet:~# 
root@meet:~# systemctl restart asterisk
root@meet:~# asterisk -x "pjsip show registrations"

 <Registration/ServerURI..............................>  <Auth..........>  <Status.......>
==========================================================================================

 reg_sipgate_2086851/sip:sipgate.de:5060                 auth_reg_sipgate_2086851  Registered      

Objects found: 1

```