### PR TITLE
Replace matratze01 with matratze03

### DIFF
--- a/group_vars/proxmox_gst.yml
+++ b/group_vars/proxmox_gst.yml
@@ -25,6 +25,7 @@ haproxy_file_extra_content: |
     http-request add-header X-Forwarded-Proto https if { ssl_fc }
     server matratze01 192.168.123.90:8006 cookie S1 check ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt
     server matratze02 192.168.123.91:8006 cookie S2 check ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt
+    server matratze03 192.168.123.92:8006 cookie S3 check ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt
 
   listen stats
      bind 127.0.0.1:2022

--- a/group_vars/proxmox_gst.yml
+++ b/group_vars/proxmox_gst.yml
@@ -23,7 +23,7 @@ haproxy_file_extra_content: |
     cookie SERVERID insert indirect nocache
     http-request set-header X-Forwarded-Port %[dst_port]
     http-request add-header X-Forwarded-Proto https if { ssl_fc }
-    server matratze01 192.168.123.90:8006 cookie S1 check ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt
+    #server matratze01 192.168.123.90:8006 cookie S1 check ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt
     server matratze02 192.168.123.91:8006 cookie S2 check ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt
     server matratze03 192.168.123.92:8006 cookie S3 check ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt
 

--- a/host_vars/matratze01.gst.hamburg.adfc.de.yml
+++ b/host_vars/matratze01.gst.hamburg.adfc.de.yml
@@ -5,8 +5,6 @@ ansible_ssh_common_args: -o ProxyCommand="ssh -W %h:%p -q root@babelfish.spdns.d
 haproxy_lets_encrypt_domains: []
 haproxy_dehydrated_domains:
   - matratze01.gst.hamburg.adfc.de
-  - matratze.gst.hamburg.adfc.de
-  - haproxy.gst.hamburg.adfc.de
 
 haproxy_cert_and_key_files:
   - /var/lib/dehydrated/certs/matratze01.gst.hamburg.adfc.de/fullchain.pem

--- a/host_vars/matratze02.gst.hamburg.adfc.de.yml
+++ b/host_vars/matratze02.gst.hamburg.adfc.de.yml
@@ -5,6 +5,8 @@ ansible_ssh_common_args: -o ProxyCommand="ssh -W %h:%p -q root@babelfish.spdns.d
 haproxy_lets_encrypt_domains: []
 haproxy_dehydrated_domains:
   - matratze02.gst.hamburg.adfc.de
+  - matratze.gst.hamburg.adfc.de
+  - haproxy.gst.hamburg.adfc.de
 
 haproxy_cert_and_key_files:
   - /var/lib/dehydrated/certs/matratze02.gst.hamburg.adfc.de/fullchain.pem

--- a/host_vars/matratze03.gst.hamburg.adfc.de.yml
+++ b/host_vars/matratze03.gst.hamburg.adfc.de.yml
@@ -1,0 +1,16 @@
+---
+ansible_host: 192.168.123.92
+ansible_ssh_common_args: -o ProxyCommand="ssh -W %h:%p -q root@babelfish.spdns.de -p 825"
+
+haproxy_lets_encrypt_domains: []
+haproxy_dehydrated_domains:
+  - matratze03.gst.hamburg.adfc.de
+
+haproxy_cert_and_key_files:
+  - /var/lib/dehydrated/certs/matratze03.gst.hamburg.adfc.de/fullchain.pem
+  - /var/lib/dehydrated/certs/matratze03.gst.hamburg.adfc.de/privkey.pem
+
+haproxy_ssl_sites:
+  - domain: matratze03.gst.hamburg.adfc.de
+    port: 8006
+    check_user_cert: true

--- a/inventory.yml
+++ b/inventory.yml
@@ -28,7 +28,7 @@ all:
           children:
             proxmox_gst:
               hosts:
-                matratze01.gst.hamburg.adfc.de:
+                #matratze01.gst.hamburg.adfc.de:
                 matratze02.gst.hamburg.adfc.de:
                 matratze03.gst.hamburg.adfc.de:
             haproxy_gst_backends:

--- a/inventory.yml
+++ b/inventory.yml
@@ -30,6 +30,7 @@ all:
               hosts:
                 matratze01.gst.hamburg.adfc.de:
                 matratze02.gst.hamburg.adfc.de:
+                matratze03.gst.hamburg.adfc.de:
             haproxy_gst_backends:
               hosts:
                 ucs-master.gst.hamburg.adfc.de:


### PR DESCRIPTION
Dieser PR entfernt das nicht mehr verwendete Proxmox-Gerät _Matratze01_ aus dem System, fügt das neue Gerät _Matratze03_ hinzu und überträgt die Rolle als Hauptgerät von _Matratze01_ auf _Matratze02_.