### PR TITLE
Add telefonanalyse to desktop autostart

### DIFF
--- a/roles/telefonanalyse/tasks/main.yml
+++ b/roles/telefonanalyse/tasks/main.yml
@@ -33,3 +33,9 @@
     src: adfc-telefonanalyse.desktop
     dest: /usr/local/share/applications/adfc-telefonanalyse.desktop
     mode: '0644'
+
+- name: Link .desktop file to XDG autostart
+  ansible.builtin.file:
+    src: /usr/local/share/applications/adfc-telefonanalyse.desktop
+    dest: /etc/xdg/autostart/adfc-telefonanalyse.desktop
+    state: link


### PR DESCRIPTION
Dieser PR wird (Georgs Wünschen entsprechend) das Programm _Telefonanalyse_ zum Autostart aller Arbeitsmaschinen hinzufügen; genauer, zum Autostart der meisten Desktop Environments unabhängig vom Benutzer.